### PR TITLE
Add resize and download to emoji board

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,14 @@
             </div>
         </div>
         <div id="canvas-wrapper">
-            <button id="clear-button">Clear Canvas</button>
+            <div class="button-bar">
+                <button id="clear-button">Clear Canvas</button>
+                <button id="download-button">Download Canvas</button>
+            </div>
             <div id="canvas" class="drop-zone"></div>
         </div>
     </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 const emojis = document.querySelectorAll('.emoji');
 const canvas = document.getElementById('canvas');
 const clearButton = document.getElementById('clear-button');
+const downloadButton = document.getElementById('download-button');
 
 emojis.forEach(emoji => {
     emoji.addEventListener('dragstart', e => {
@@ -21,10 +22,24 @@ canvas.addEventListener('drop', e => {
         span.textContent = data;
         span.style.left = e.offsetX + 'px';
         span.style.top = e.offsetY + 'px';
+        span.addEventListener('dblclick', () => {
+            const size = parseFloat(window.getComputedStyle(span).fontSize);
+            span.style.fontSize = size + 10 + 'px';
+        });
         canvas.appendChild(span);
     }
 });
 
 clearButton.addEventListener('click', () => {
     canvas.innerHTML = '';
+});
+
+downloadButton.addEventListener('click', () => {
+    if (typeof html2canvas === 'undefined') return;
+    html2canvas(canvas).then(c => {
+        const link = document.createElement('a');
+        link.download = 'emoji-mood-board.png';
+        link.href = c.toDataURL('image/png');
+        link.click();
+    });
 });

--- a/style.css
+++ b/style.css
@@ -50,13 +50,20 @@ body {
     flex-direction: column;
 }
 
-#clear-button {
+#clear-button,
+#download-button {
     background: #ff69b4;
     color: white;
     border: none;
     padding: 10px;
     font-size: 1rem;
     cursor: pointer;
+}
+
+.button-bar {
+    display: flex;
+    gap: 10px;
+    padding: 10px;
 }
 
 #canvas {
@@ -73,5 +80,6 @@ body {
 .dropped-emoji {
     position: absolute;
     font-size: 2rem;
-    pointer-events: none;
+    pointer-events: auto;
+    user-select: none;
 }


### PR DESCRIPTION
## Summary
- add Download Canvas button and html2canvas library
- style new button bar
- allow emojis to be enlarged on double-click
- enable downloading the canvas as an image

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c6349c7ac8323874980d2be5302b5